### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@
 - Step 2: Build test jar.
 
   - Modify flink version and hive version of `pom.xml`.
-  
+
+    Notice：flink version should use x.y.z such as 1.11.2 .
+
   - `mvn clean install`
   
 - Step 3: Run


### PR DESCRIPTION
Some jar like flink-orc-nohive_2.11 this project depend on,there is no such version as 1.11-SNAPSHOT.We need to specify the complete version. Maybe we can use "maven activation"  to solve this problem. This pom use spark version x.y  refer to spark complete. ’https://github.com/Intel-bigdata/HiBench/blob/master/sparkbench/pom.xml’  can be used as a reference.